### PR TITLE
Explicitly define property $compileCache

### DIFF
--- a/lib/ReckiCT/Compiler/PHP/Compiler.php
+++ b/lib/ReckiCT/Compiler/PHP/Compiler.php
@@ -49,6 +49,7 @@ class Compiler extends BaseCompiler
         '>>',
     ];
 
+    protected $compileCache = [];
 
     public function convertToCallable(array $instructions)
     {


### PR DESCRIPTION
This was defined in JitFu\Compiler but not PHP\Compiler. Could theoretically be moved to the abstract Compiler, but that doesn't feel right.
