### PR TITLE
Improved Version Constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     
     "require": {
         "php-64bit": ">=5.5.0",
-        "nikic/php-parser": "dev-master",
+        "nikic/php-parser": "1.0.*@dev",
         "phpdocumentor/reflection-docblock": "2.0.*",
         "sdboyer/gliph": "0.6.*"
     },
 
     "require-dev": {
         "phpunit/phpunit": "4.*",
-        "phploc/phploc": "*",
+        "phploc/phploc": "2.*",
         "phpdocumentor/graphviz": "1.0.*",
         "mockery/mockery": "0.9.*",
-        "phake/phake": "2.0.0-beta2"
+        "phake/phake": "2.0.*@beta"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A Compiler Toolkit for PHP.",
     "license": "Apache-2.0",
     "keywords": ["compile", "compiler", "jit", "ast", "cfg", "ssa"],
-    
+
     "homepage": "https://github.com/google/recki-ct",
 
     "support": {
@@ -18,7 +18,7 @@
             "role": "Developer"
         }
     ],
-    
+
     "require": {
         "php-64bit": ">=5.5.0",
         "nikic/php-parser": "1.0.*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "b81bd08a6bf1d20f67367d0ad3b6dd70",
+    "hash": "4853e821229e9ff7bc5f8c181a055f8a",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -1398,18 +1399,15 @@
             "time": "2014-02-19 00:20:43"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "nikic/php-parser": 20,
         "phake/phake": 10
     },
+    "prefer-stable": false,
     "platform": {
         "php-64bit": ">=5.5.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }


### PR DESCRIPTION
- Firstly, seeing `dev-master` for `nikic/php-parser` makes me sad. I've changed it to `1.0.*@dev`.
- Secondly, seeing `*` for `phploc/phploc` makes me sad too. I've changed it to `2.*`.
- Finally, I've tweaked the version constraint of `phake/phake` to make it an actual version constraint. My version constraint say get any 2.0.x version provided it has a stability of beta or higher.

This project looks pretty cool @ircmaxell. I'm looking forward to the future. :)
